### PR TITLE
Insert after ActiveRecord::QueryCache

### DIFF
--- a/lib/active_record_multiple_query_cache.rb
+++ b/lib/active_record_multiple_query_cache.rb
@@ -14,7 +14,7 @@ module ActiveRecordMultipleQueryCache
       executor.register_hook(hook)
     else
       middleware = Rails4QueryCache.new(activerecord_base_class_name)
-      rails.configuration.app_middleware.insert_after('::ActionDispatch::Callbacks', middleware)
+      rails.configuration.app_middleware.insert_after('ActiveRecord::QueryCache', middleware)
     end
   end
 end


### PR DESCRIPTION
`./bin/rake middleware`

rackの挿入位置が意図しない場所にあったため、正しくコネクションが管理されない問題があったので修正。

**before**

```
...
use ActionDispatch::Callbacks
use #<ActiveRecordMultipleQueryCache::Rails4QueryCache active_record_class: "XXX">
use #<ActiveRecordMultipleQueryCache::Rails4QueryCache active_record_class: "XXX">
use ActiveRecord::ConnectionAdapters::ConnectionManagement
use Airbrake::Rack::Middleware
use ActiveRecord::QueryCache
...
```

**after**

```
...
use ActiveRecord::ConnectionAdapters::ConnectionManagement
use Airbrake::Rack::Middleware
use ActiveRecord::QueryCache
use #<ActiveRecordMultipleQueryCache::Rails4QueryCache active_record_class: "XXX">
use #<ActiveRecordMultipleQueryCache::Rails4QueryCache active_record_class: "XXX">
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
...
```